### PR TITLE
Fix TypeError when using kwargs['cursorclass']

### DIFF
--- a/flask_pymysql/__init__.py
+++ b/flask_pymysql/__init__.py
@@ -28,7 +28,8 @@ class MySQL(object):
         if current_app.config['pymysql_kwargs']:
             kwargs = current_app.config['pymysql_kwargs']
             if 'cursorclass' in kwargs.keys():
-                kwargs['cursorclass'] = getattr(cursors, kwargs['cursorclass'])
+                if isinstance(kwargs['cursorclass'], str):
+                    kwargs['cursorclass'] = getattr(cursors, kwargs['cursorclass'])
         else:
             kwargs = dict()
 


### PR DESCRIPTION
The cursorclass kwarg is automatically resolved from the
string name passed in the dict, however this causes a TypeError
when a connection is made more than once (that is, on two different
requests). This pull request makes the routine first check whether the
argument is a string, and in this way makes sure that the value has already
been resolved. This also allows for the user to pass a cursor class directly.